### PR TITLE
Update main.cpp to remove space that breaks code

### DIFF
--- a/winui3-without-midl/main.cpp
+++ b/winui3-without-midl/main.cpp
@@ -1,4 +1,4 @@
-# include "pch.h"
+#include "pch.h"
 
 using namespace winrt;
 using namespace Microsoft::UI::Xaml;


### PR DESCRIPTION
The space between `#` and `include` prevents the code from building.